### PR TITLE
The following scripts are suposed to run with hardhat run time environment

### DIFF
--- a/contracts/Spades.sol
+++ b/contracts/Spades.sol
@@ -3,8 +3,13 @@ pragma solidity 0.8.19;
 
 import "hardhat/console.sol";
 
-/// @title A multisignature wallet called Spades
-/// @author Filipe Rey
+/**
+ * @title   DAOsigs - A DAO / CrowdFunding contract integrated with a multi-signature wallet when deployed
+ * @author  
+ * @dev     Supports ERC-20 interface.
+ * @notice  This is a basic crowd funding / DAO contract with a multi-signature 
+ * feature. This requires the need for owners to sign function calls to submit an action. 
+*/
 
 contract Spades {
 
@@ -24,7 +29,7 @@ contract Spades {
     event revoked (address sender, uint _txNonce);
 
     ///@notice This is what's inside a transaction
-        ///@dev returns data when interacting with other contracts
+        ///@dev Returns data when interacting with other contracts
 
     struct Transaction {
         address to;
@@ -48,8 +53,9 @@ contract Spades {
         // equals true if that owner already signed;
     mapping (uint => mapping (address => bool)) whoSigned;
 
+    ///@dev Stores tx Index;
+     /// Starts at index 0;
 
-        // Stores tx Index;
     mapping (uint => Transaction) public txMap;
     uint txNonce;
 
@@ -92,7 +98,7 @@ contract Spades {
     }
 
         // Submits a transaction 
-    function submit(address _to, uint _amount, bytes memory _data) public ownerOnly {
+    function submit(address payable _to, uint _amount, bytes memory _data) public ownerOnly {
 
         transaction = Transaction({
             to: _to,
@@ -102,19 +108,22 @@ contract Spades {
             data: _data,
             executed: false
         });
-    
+
+    ///@dev After submiting the msg.sender is a signed owner;
+    // txNonce incresases by one;
+
         txMap[txNonce] = transaction;
         whoSigned[txNonce][msg.sender] = true;
         txNonce ++;
 
-        emit Submit(msg.sender, _amount, txNonce -1, _data);
+        emit Submit(msg.sender, _amount, txNonce, _data);
 
     }
     
         // Returns a transaction when given the tx_index
     function getTransaction(uint txIndex) public view returns (address to, uint amount, uint confirmations, address signature) {
     
-        Transaction storage transaction = txMap[txIndex];
+        Transaction memory transaction = txMap[txIndex];
 
         return (
             transaction.to,
@@ -131,7 +140,7 @@ contract Spades {
 
         // Signs a transaction that was submited from another owner
     function signTransaction(uint txIndex) public ownerOnly txExists(txIndex){
-        Transaction storage transaction = txMap[txIndex];
+        Transaction memory transaction = txMap[txIndex];
         require(whoSigned[txIndex][msg.sender] == false);
         transaction.confirmations += 1;
         whoSigned[txIndex][msg.sender] = true;
@@ -141,18 +150,20 @@ contract Spades {
 
         // Revokes a signature that was already made
     function revokeConfirmation(uint txIndex) public txExists(txIndex) notExecuted(txIndex) ownerOnly {
-        Transaction storage transaction = txMap[txIndex];
+        Transaction memory transaction = txMap[txIndex];
 
         require(whoSigned[txIndex][msg.sender] == true, "You didn't sign this transaction");
-        transaction.confirmations -= 1;
+        transaction.confirmations - 1;
+        whoSigned[txIndex][msg.sender] = false;
 
         emit revoked (msg.sender, txIndex);
 
     }
     
-        // Executes the transaction after reaching the required signatures  
+       /// @notice Executes the transaction after reaching the required signatures;
+
    function executeTransaction(uint txIndex) public txExists(txIndex) {
-        Transaction storage transaction = txMap[txIndex];
+        Transaction memory transaction = txMap[txIndex];
         require(transaction.confirmations >= requiredSignatures, "Not enough signatures");
         (bool success, ) = transaction.to.call{value: transaction.amount}(
             transaction.data);

--- a/scripts/Deployment.ts
+++ b/scripts/Deployment.ts
@@ -17,12 +17,13 @@ async function main() {
 
         ///Init accounts
         accounts = await ethers.getSigners();
+        
 
         /// Deploying contract;
         /// ---------------------
 
         const contractFactory = new Spades__factory(accounts[0]);
-        const contract = await contractFactory.deploy([accounts[0], accounts[1], accounts[2]], 2, {value: 100});
+        const contract = await contractFactory.deploy([accounts[0], accounts[1], accounts[2]], 1, {value: 100});
         await contract.waitForDeployment();
         const spadesAddress= await contract.getAddress();
 
@@ -37,11 +38,12 @@ async function main() {
         // Submit a transaction
         // Define 'amount' and 'data' here with appropriate values
 
-        const amount = ethers.parseUnits("2"); // Replace with desired amount
+        const amountInEther = 4;
+        const weiAmount = ethers.parseEther(amountInEther.toString());
         const binaryData = new Uint8Array([0x17, 0x60, 0x6c, 0x4c, 0x6f]);
-        const data = ethers.keccak256(binaryData);
+        //const data = ethers.keccak256(binaryData);
 
-        const tx = await contract.connect(accounts[1]).submit(accounts[2], amount, data);
+        const tx = await contract.connect(accounts[1]).submit(accounts[2].address, weiAmount, binaryData);
         const receipt = await tx.wait();
             
         console.log(`Submitted transaction from ${accounts[1].address}:\n 
@@ -55,7 +57,7 @@ async function main() {
 
         // Signing a transaction 
         // Index [0] with accounts [0]
-        const signature = contract.connect(accounts[0]).signTransaction(0);
+        const signature = contract.signTransaction(0);
         await signature;
 
         console.log(`\nAccount with address ${accounts[0].address}
@@ -78,22 +80,32 @@ async function main() {
         const firstSignature = await contract.seeIfSigned(0, accounts[1].address);
         await firstSignature;
 
-        console.log(`The account ${accounts[0].address} signed the tx: ${firstSignature}`);
+        console.log(`The account ${accounts[1].address} signed the tx: ${firstSignature}`);
+
+        // Signing with account [2]
+        const signature2 = contract.connect(accounts[2]).signTransaction(0);
+        await signature2;
+
+        console.log(`\nAccount with address ${accounts[2].address}
+        signed the tx with index 0.\n`);
+
+        const seeSignaturesAgain = await contract.seeIfSigned(0, accounts[2].address);
+        await seeSignaturesAgain;
+
+        console.log(`The account ${accounts[2].address} signed this tx: ${seeSignaturesAgain}`);
+    
 
         // Revoke a confirmation
-        //TODO
+        const revokeOwner2 = contract.connect(accounts[2]).revokeConfirmation(0);
+        await (await revokeOwner2).wait();
+
+        const seeSignatures2 = await contract.seeIfSigned(0, accounts[2]);
 
 
-        // Sign the transaction again
-        //TODO
+        console.log(`The account ${accounts[2].address} signed this tx: ${seeSignatures2}\n`);
 
 
-        // Execute the transaction
-        // TODO
-
-        
-        // Fetch contract balance
-        //TODO
+        // Working on the contract function to execute;
 
         
     } catch (error) {


### PR DESCRIPTION
The script submitted is challenging the contract logic and interaction. First evoking hardhat accounts `accounts = await ethers.getSigners();` before deploying the contract with multiple addresses as owners: `const contract = await contractFactory.deploy([accounts[0], accounts[1], accounts[2]], 1, {value: 100});
` transacting a value of 100 ETH.

After deployment we test all the contract logic, by:

- Submitting a transaction from account1 to account2;
- Query transactions passing the index;
- Sign a transaction with account0;
- See owners who already signed the transaction;
- Revoking a confirmation;

