### PR TITLE
Building a withdraw limit proposal system. Each owner can submit a withdraw limit for other accounts, to be signed by the owners. 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorTheme": "Monokai"
+}

--- a/contracts/Spades.sol
+++ b/contracts/Spades.sol
@@ -5,116 +5,107 @@ import "hardhat/console.sol";
 
 /**
  * @title  Spades Multisig
- * @author  Filipe Rey
+ * @author  Filipe Reys
  *
  * @notice  This is a multisignature wallet that permits several owners
- *  targetAccount submit and sign on transactions, for an extra layer of security.
- * Who ever is an owner can revoke confirmations and set withdraw dailyWithdrawlimits for 
- * the rest of the owners, if they agree.
+ *  to submit and sign on transactions, for an extra layer of security.
+ * Who ever is an owner can revoke confirmations and set withdraw limits for 
+ * the rest of the owners, if all agree.
 */
 
-contract Spades {
+contract Spades {       
+
+                        //////////////// EVENTS ///////////////////
+                    //////////////////////////////////////////////////
+                        //////////////////////////////////////////
 
         // Emits a deposit. 
     event Deposit (address sender, uint _value, uint _balance);
-
         // Transaction was submited. 
     event Submit (address _targetAccount, uint _amount, uint _txNonce, bytes data);
-
         // Transaction was signed.
     event Sign (address _owner, uint _txNonce);
-
         // Transaction executed.
     event transactionExecuted (address sender, uint _txNonce);
-
         // Transaction was revoked.
     event revoked (address sender, uint _txNonce);
-
         // Submits an account withdraw limit.
-    event accountLimit (address _targetAccount, uint _amount, uint _accountIndex);
-
+    event accountLimit (address _targetAccount, uint _amount, uint _setingsProposedNonce);
         // Signs an account limit.
-    event signedSettings (address _owner, uint _accountIndex);
-
+    event signedSettings (address _owner, uint _setingsProposedNonce);
         // Triggers a withdraw.
     event withdrawEvent (address _owner, uint _amount);
 
-    ///@notice This struct stargetAccountres account specific informations.
+   
 
-    struct Account {
+                        //////////////// Global Variables ///////////////////
+                    ///////////////////////////////////////////////////////////
+                        ///////////////////////////////////////////////////
 
-        address proposer;
-        uint lastWithdrawalTimestamp;
-        uint approvals;
+
+    address[] public owners;  // Array to store owners addresses.
+    uint public requiredSignatures;  // Stores required signatures passed in the constructor.
+    uint txNonce;  // Keeps track of tx nonce, starts at 0.
+    uint setingsProposedNonce; // Keeps track of submited account settings nonce.
+
+
+    mapping(address => bool) public OwnersCheck;
+    mapping (uint => mapping (address => bool)) whoSignedTx; // Goes from an uint request (TxIndex) to the address (Owner) that signed a transaction.
+    mapping (uint => mapping (address => bool)) whoSignedProposedSettings; // Goes from an uint request (settingIndex) to the address (Owner) that signed a proposed setting.    
+    /// Equals true if that owner already signed.
+
+    mapping (uint => Transaction) public txMap;  // Connects the uint TxIndex nonce to the struct Transaction.
+    mapping (uint => ProposedSettings) public submitedSettingsMap; // Conects the settings proposed nonce to the struct proposedSettings.
+    mapping (address => Settings) public accountSettings; // Connects the account (owner address) to the settings defined.
+
+
+    struct ProposedSettings {
+
+        uint confirmations;
         uint dailyWithdrawlimit;
-        address targetAccount;
-        bool executed;
+        address owner;
     }
-    Account public account;
-
-
-    ///@notice This is whauintt's inside a transaction.
-        ///@dev Returns data when interacting with other contracts.
 
     struct Transaction {
 
         address targetAccount;
         uint amount;
         uint confirmations;
-        address signature;
         bytes data;
-        bool executed;
     }
 
-    Transaction public transaction;
+    struct Settings {
 
-        // StargetAccountres owners addresses.
-    address[] public owners;
-    mapping(address => bool) public OwnersCheck;
+        uint withdrawLimit;
+        uint withdrawTimestamp;
+        
+    }
 
-        // StargetAccountres the required Signatures passed in the constructargetAccountr().
-    uint public requiredSignatures;
+                        //////////////// Modifiers  ///////////////////
+                    ///////////////////////////////////////////////////////////
+                        ///////////////////////////////////////////////////
+                        
 
-        // Goes from an uint Request(TxIndex) targetAccount the address (Owner) that signed a transaction
-        // equals true if that owner already signed.
-    mapping (uint => mapping (address => bool)) whoSignedTx;
-
-        // Goes from an uint (TxIndex) targetAccount the address (Owner) that signed the account settings pending
-        // equals true if that owner already signed.
-    mapping (uint => mapping (address => bool)) whoSignedSettings;
-
-    ///@dev StargetAccountres tx index, starts at 0;
-    mapping (uint => Transaction) public txMap;
-    uint txNonce;
-
-    ///@dev StargetAccountres account settings request.
-    mapping (uint => Account) public submitedSettings;
-    uint accountIndex;
-
-
-    ///@dev Conects the account targetAccount an address
-    mapping (address => Account) public accountInfo;
-
-
-        // Checks if msg.sender is owner.
     modifier ownerOnly() {
-        require(OwnersCheck[msg.sender], "You're not an owner of Spades");
+        require(OwnersCheck[msg.sender], "You're not an owner of Spades"); // Checks if msg.sender is owner.
         _;
     }
 
-        // Checks if transaction exists. 
     modifier txExists(uint _txIndex) {
-        require(_txIndex < txNonce, "Tx doesn't exist");
+        require(_txIndex < txNonce, "Tx doesn't exist"); // Checks if transaction exists. 
         _;
     }
 
-        // Checks if the tx was not executed.
-    modifier notExecuted(uint _txIndex) {
-        require(txMap[_txIndex].executed == false, "Transaction was already executed");
-        _;
-    }
 
-        // Sets the number of owners and signatures needed. 
+                        ////////////////  Logic Functions  ///////////////////
+                        ///////////////////////////////////////////////////////////
+                        ///////////////////////////////////////////////////
+
+
+    ///@notice Sets the number of owners and signatures needed.
+    ///@dev Input of owners need to be more than zero. 
+    // Signatures required need to be more than zero and less or equal to number of owners passed.
+
     constructor (address[] memory _owners, uint _signaturesRequired) payable {
 
         require(_owners.length > 0, "Not enough owners");
@@ -130,56 +121,36 @@ contract Spades {
        requiredSignatures = _signaturesRequired;
     }
     
-        // Contract can receive Ether. 
+    /// Contract can receive Ether. 
     receive() external payable {
         emit Deposit (msg.sender, msg.value, address(this).balance);
     }
 
-        // Submits a transaction targetAccount be signed by required owners. 
+
+    /// Submits a transaction _to (address) to be signed by required number of owners. 
     function submit(address payable _targetAccount, uint _amount, bytes memory _data) public ownerOnly {
 
-        transaction = Transaction ({
+        Transaction memory transaction = Transaction ({
+
             targetAccount: _targetAccount,
             amount: _amount,
             confirmations: 1,
-            signature: msg.sender,
-            data: _data,
-            executed: false
+            data: _data
+    
         });
 
-    ///@dev After submiting the msg.sender is a signed owner;
+    ///@dev After submiting, the msg.sender is a signed owner;
     // txNonce incresases by one;
 
         txMap[txNonce] = transaction;
         whoSignedTx[txNonce][msg.sender] = true;
         txNonce ++;
-
-        emit Submit(msg.sender, _amount, txNonce, _data);
-
-    }
-    
-        // Returns a transaction when given the tx_index.
-    function getTransaction(uint txIndex) public view returns (address targetAccount, uint amount, uint confirmations, address signature, bool executed) {
-    
-        Transaction storage transaction = txMap[txIndex];
-
-        return (
-            transaction.targetAccount,
-            transaction.amount,
-            transaction.confirmations,
-            transaction.signature,
-            transaction.executed
-        );
+        emit Submit(msg.sender, _amount, txNonce - 1, _data);
     }
 
-        // Can check who already signed the transaction.
-    function seeIfSigned(uint txIndex, address _owner) public view returns (bool) {
 
-        return whoSignedTx[txIndex][_owner];
-    }
-
-        // Signs a transaction that was submited from another owner.
-    function signTransaction(uint txIndex) public ownerOnly txExists(txIndex){
+    /// Signs a transaction that was submited from another owner.
+    function signTransaction(uint txIndex) public ownerOnly txExists(txIndex) {
 
         Transaction storage transaction = txMap[txIndex];
         require(whoSignedTx[txIndex][msg.sender] == false);
@@ -189,101 +160,118 @@ contract Spades {
         emit Sign (msg.sender, txIndex);
     }
 
-        // Revokes a signature that was already made.
-    function revokeConfirmation(uint txIndex) public txExists(txIndex) notExecuted(txIndex) ownerOnly {
-
-        Transaction storage transaction = txMap[txIndex];
+    /// Revokes a signature that was already made.
+    function revokeConfirmation(uint txIndex) public txExists(txIndex) ownerOnly {
 
         require(whoSignedTx[txIndex][msg.sender] == true, "You didn't sign this transaction");
-        transaction.confirmations - 1;
+        
+        txMap[txIndex].confirmations -= 1;
         whoSignedTx[txIndex][msg.sender] = false;
 
         emit revoked (msg.sender, txIndex);
-
     }
     
-       /// @notice Executes the transaction passed in submit function after reaching the required signatures;
+    //// @notice Executes the transaction passed in submit function after reaching the required signatures;
 
    function executeTransaction(uint txIndex) public txExists(txIndex) {
+        Transaction memory transaction = txMap[txIndex];
 
-        Transaction storage transaction = txMap[txIndex];
         require(transaction.confirmations >= requiredSignatures, "Not enough signatures");
         (bool success, ) = transaction.targetAccount.call{value: transaction.amount}(
             transaction.data);
-        require(success, "Tx failed targetAccount execute");
-        txMap[txIndex].executed = true;
-        transaction.executed = true;
 
+        require(success, "Tx failed targetAccount execute");
+
+        delete txMap[txIndex];
+        
         emit transactionExecuted (msg.sender, txIndex);
    }
-        ///@notice Will submit an account limit targetAccount be signed by the other owners.
+
+        ///@notice Will submit an account limit for the owner, to be signed and reach required signatures.
         ///@dev The last withdraw timestamp approved must be fetched for the address submited.
 
    function submitAccountLimit(address _account, uint _dailyWithdrawlimit) public ownerOnly {
 
         require(_dailyWithdrawlimit >= 0, "Invalid dailyWithdrawlimit");
         require(OwnersCheck[_account] = true, "Address does not match with any of the owners.");
-        uint accountTimestamp = accountInfo[_account].lastWithdrawalTimestamp;
 
-        account = Account({
+        ProposedSettings memory proposedSettings  = ProposedSettings ({
 
-            proposer: msg.sender,
-            lastWithdrawalTimestamp: accountTimestamp,
-            approvals: 1,
+            confirmations: 1,
             dailyWithdrawlimit: _dailyWithdrawlimit,
-            targetAccount: _account,
-            executed: false
+            owner: _account
+
         });
 
-        submitedSettings[accountIndex] = account;
-        whoSignedSettings[accountIndex][msg.sender] = true;
-        accountIndex ++;
+        submitedSettingsMap[setingsProposedNonce] = proposedSettings;
+        whoSignedProposedSettings[setingsProposedNonce][msg.sender] = true;
+        setingsProposedNonce ++;
 
-        emit accountLimit ( _account, _dailyWithdrawlimit, accountIndex);
+        emit accountLimit ( _account, _dailyWithdrawlimit, setingsProposedNonce - 1);
 
-        
-   }
+    }
+   
 
-
-   function signSettings(uint256 _proposedSettings) public ownerOnly {
-    signFunction(_proposedSettings);
-
-    emit signedSettings(msg.sender, _proposedSettings);
-
-}
 
     ///@dev This signs the request for the setting, after reaching
     // the required signatures will execute by itself. Can only be called within this contract.
 
-   function signFunction(uint _proposedSettings) internal {
+   function signSettings(uint _proposedSettingsIndex) internal {
 
-        require(whoSignedSettings[_proposedSettings][msg.sender] == false, "Owner already signed this settings");
-        Account storage account = submitedSettings[_proposedSettings];
-        account.approvals += 1;
-        whoSignedSettings[_proposedSettings][msg.sender] == true;
+        require(whoSignedProposedSettings[_proposedSettingsIndex][msg.sender] == false, "Owner already signed this settings");
+        ProposedSettings memory proposedSettings = submitedSettingsMap[_proposedSettingsIndex];
+        proposedSettings.confirmations += 1;
+        whoSignedProposedSettings[_proposedSettingsIndex][msg.sender] == true;
 
-        if (account.approvals >= requiredSignatures && !account.executed) {
-            accountInfo[account.targetAccount].dailyWithdrawlimit = account.dailyWithdrawlimit;
-            account.executed = true;
+        if (proposedSettings.confirmations >= requiredSignatures) {
+
+            Settings memory settingsDefined = accountSettings[proposedSettings.owner];
+            settingsDefined.withdrawLimit = proposedSettings.dailyWithdrawlimit;
+            settingsDefined.withdrawTimestamp = block.timestamp;
+            delete submitedSettingsMap[_proposedSettingsIndex];
             
         }
-
    }
+
 
    ///@notice Can make a withdraw if the amount is lesser or equal to the account daily withdraw limit.
 
     function withdraw(uint amount) public ownerOnly {
-        require(amount <= accountInfo[msg.sender].dailyWithdrawlimit, "Exceeded withdraw limit");
-        require(block.timestamp >= accountInfo[msg.sender].lastWithdrawalTimestamp + 1 days, "Daily limit haven't reset yet");
+
+        Settings memory settingsDefined = accountSettings[msg.sender];
+        require(amount <= accountSettings[msg.sender].withdrawLimit, "Exceeded withdraw limit");
+        require(block.timestamp >= accountSettings[msg.sender].withdrawTimestamp + 1 days, "Daily limit haven't reset yet");
         require(amount <= address(this).balance, "Insufficient balance");
         payable(msg.sender).transfer(amount);
 
         emit withdrawEvent (msg.sender, amount);
    }
 
+                            ////////////////  View Functions  ///////////////////
+                    ///////////////////////////////////////////////////////////
+                        ///////////////////////////////////////////////////
+
         // View contract Spades balance 
    function spadesBalance() public view ownerOnly returns (uint256) {
     return address(this).balance;
    }
 
+       /// Returns a transaction when given the tx_index.
+    function getTransaction(uint txIndex) public view returns (address targetAccount, uint amount, uint confirmations, bytes memory data) {
+    
+        Transaction memory transaction = txMap[txIndex];
+
+        return (
+            transaction.targetAccount,
+            transaction.amount,
+            transaction.confirmations,
+            transaction.data);
+    }
+
+    /// Can check who already signed the transaction.
+    function seeIfSigned(uint txIndex, address _owner) public view returns (bool) {
+        return whoSignedTx[txIndex][_owner];
+    }
+
 }
+    

--- a/contracts/Spades.sol
+++ b/contracts/Spades.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.19;
 import "hardhat/console.sol";
 
 /**
- * @title   DAOsigs - A DAO / CrowdFunding contract integrated with a multi-signature wallet when deployed
- * @author  
- * @dev     Supports ERC-20 interface.
- * @notice  This is a basic crowd funding / DAO contract with a multi-signature 
- * feature. This requires the need for owners to sign function calls to submit an action. 
+ * @title  Spades Multisig
+ * @author  Filipe Rey
+ *
+ * @notice  This is a multisignature wallet that permits several owners
+ *  to submit and sign on transactions, for an extra layer of security.
+ * Who ever is an owner can revoke confirmations and set withdraw dailyWithdrawlimits for 
+ * the rest of the owners, if they agree.
 */
 
 contract Spades {
@@ -28,10 +30,24 @@ contract Spades {
         // Transaction was revoked
     event revoked (address sender, uint _txNonce);
 
-    ///@notice This is what's inside a transaction
-        ///@dev Returns data when interacting with other contracts
+    ///@notice This struct stores account specific informations.
+
+    struct Account {
+
+        address proposer;
+        uint lastWithdrawalTimestamp;
+        uint approvals;
+        uint dailyWithdrawlimit;
+        address to;
+    }
+    Account public account;
+
+
+    ///@notice This is whauintt's inside a transaction.
+        ///@dev Returns data when interacting with other contracts.
 
     struct Transaction {
+
         address to;
         uint amount;
         uint confirmations;
@@ -42,42 +58,53 @@ contract Spades {
 
     Transaction public transaction;
 
-        // Stores owners addresses 
-    address[] private owners;
+        // Stores owners addresses.
+    address[] public owners;
     mapping(address => bool) public OwnersCheck;
 
-        // Stores the required Signatures passed in the constructor()
+        // Stores the required Signatures passed in the constructor().
     uint public requiredSignatures;
 
-        // Goes from an uint (TxIndex) to the address (Owner) that signed a tx
-        // equals true if that owner already signed;
-    mapping (uint => mapping (address => bool)) whoSigned;
+        // Goes from an uint Request(TxIndex) to the address (Owner) that signed a transaction
+        // equals true if that owner already signed.
+    mapping (uint => mapping (address => bool)) whoSignedTx;
 
-    ///@dev Stores tx Index;
-     /// Starts at index 0;
+        // Goes from an uint (TxIndex) to the address (Owner) that signed the account settings pending
+        // equals true if that owner already signed.
+    mapping (uint => mapping (address => bool)) whoSignedSettings;
 
+    ///@dev Stores tx index, starts at 0;
     mapping (uint => Transaction) public txMap;
     uint txNonce;
 
-        // Checks if msg.sender is owner 
+    ///@dev Stores account settings request.
+    mapping (uint => Account) public submitedSettings;
+    uint accountIndex;
+
+
+    ///@dev Conects the account to an address
+    mapping (address => Account) public accountInfo;
+
+
+        // Checks if msg.sender is owner.
     modifier ownerOnly() {
         require(OwnersCheck[msg.sender], "You're not an owner of Spades");
         _;
     }
 
-        // Checks if transaction exists 
+        // Checks if transaction exists. 
     modifier txExists(uint _txIndex) {
         require(_txIndex < txNonce, "Tx doesn't exist");
         _;
     }
 
-        // Checks if the tx was not executed
+        // Checks if the tx was not executed.
     modifier notExecuted(uint _txIndex) {
         require(txMap[_txIndex].executed == false, "Transaction was already executed");
         _;
     }
 
-        // Sets the number of owners and signatures needed 
+        // Sets the number of owners and signatures needed. 
     constructor(address[] memory _owners, uint _signaturesRequired) payable {
         require(_owners.length > 0, "Not enough owners");
         require(_signaturesRequired > 0 && _signaturesRequired <= _owners.length, "Signatures required must be greater than 0 and less than the owners defined ");
@@ -92,12 +119,12 @@ contract Spades {
        requiredSignatures = _signaturesRequired;
     }
     
-        // Receive Ether 
+        // Contract can receive Ether. 
     receive() external payable {
         emit Deposit (msg.sender, msg.value, address(this).balance);
     }
 
-        // Submits a transaction 
+        // Submits a transaction to be signed by required owners. 
     function submit(address payable _to, uint _amount, bytes memory _data) public ownerOnly {
 
         transaction = Transaction({
@@ -113,64 +140,129 @@ contract Spades {
     // txNonce incresases by one;
 
         txMap[txNonce] = transaction;
-        whoSigned[txNonce][msg.sender] = true;
+        whoSignedTx[txNonce][msg.sender] = true;
         txNonce ++;
 
         emit Submit(msg.sender, _amount, txNonce, _data);
 
     }
     
-        // Returns a transaction when given the tx_index
-    function getTransaction(uint txIndex) public view returns (address to, uint amount, uint confirmations, address signature) {
+        // Returns a transaction when given the tx_index.
+    function getTransaction(uint txIndex) public view returns (address to, uint amount, uint confirmations, address signature, bool executed) {
     
-        Transaction memory transaction = txMap[txIndex];
+        Transaction storage transaction = txMap[txIndex];
 
         return (
             transaction.to,
             transaction.amount,
             transaction.confirmations,
-            transaction.signature
+            transaction.signature,
+            transaction.executed
         );
     }
 
-        // Can check who already signed the transaction
+        // Can check who already signed the transaction.
     function seeIfSigned(uint txIndex, address _owner) public view returns (bool) {
-        return whoSigned[txIndex][_owner];
+        return whoSignedTx[txIndex][_owner];
     }
 
-        // Signs a transaction that was submited from another owner
+        // Signs a transaction that was submited from another owner.
     function signTransaction(uint txIndex) public ownerOnly txExists(txIndex){
-        Transaction memory transaction = txMap[txIndex];
-        require(whoSigned[txIndex][msg.sender] == false);
+        Transaction storage transaction = txMap[txIndex];
+        require(whoSignedTx[txIndex][msg.sender] == false);
         transaction.confirmations += 1;
-        whoSigned[txIndex][msg.sender] = true;
+        whoSignedTx[txIndex][msg.sender] = true;
         
         emit Sign (msg.sender, txIndex);
     }
 
-        // Revokes a signature that was already made
+        // Revokes a signature that was already made.
     function revokeConfirmation(uint txIndex) public txExists(txIndex) notExecuted(txIndex) ownerOnly {
-        Transaction memory transaction = txMap[txIndex];
+        Transaction storage transaction = txMap[txIndex];
 
-        require(whoSigned[txIndex][msg.sender] == true, "You didn't sign this transaction");
+        require(whoSignedTx[txIndex][msg.sender] == true, "You didn't sign this transaction");
         transaction.confirmations - 1;
-        whoSigned[txIndex][msg.sender] = false;
+        whoSignedTx[txIndex][msg.sender] = false;
 
         emit revoked (msg.sender, txIndex);
 
     }
     
-       /// @notice Executes the transaction after reaching the required signatures;
+       /// @notice Executes the transaction passed in submit function after reaching the required signatures;
 
    function executeTransaction(uint txIndex) public txExists(txIndex) {
-        Transaction memory transaction = txMap[txIndex];
+
+        Transaction storage transaction = txMap[txIndex];
         require(transaction.confirmations >= requiredSignatures, "Not enough signatures");
         (bool success, ) = transaction.to.call{value: transaction.amount}(
             transaction.data);
         require(success, "Tx failed to execute");
         txMap[txIndex].executed = true;
+        transaction.executed = true;
 
         emit transactionExecuted (msg.sender, txIndex);
+   }
+        ///@notice Will submit an account limit to be signed by the other owners.
+        ///@dev The last withdraw timestamp approved must be fetched for the address submited.
+
+   function submitAccountLimit(address _account, uint _dailyWithdrawlimit) public ownerOnly {
+        require(_dailyWithdrawlimit >= 0, "Invalid dailyWithdrawlimit");
+        require(OwnersCheck[_account] = true, "Address does not match with any of the owners.");
+        uint accountTimestamp = accountInfo[_account].lastWithdrawalTimestamp;
+
+        account = Account({
+
+            proposer: msg.sender,
+            lastWithdrawalTimestamp: accountTimestamp,
+            approvals: 1,
+            dailyWithdrawlimit: _dailyWithdrawlimit,
+            to: _account
+        });
+
+        submitedSettings[accountIndex] = account;
+        whoSignedSettings[accountIndex][msg.sender] = true;
+        accountIndex ++;
+        
+   }
+    ///@dev This signs the request for the setting, after reaching
+    // the required signatures will execute by itself.
+
+   function signAccountLimit(uint _proposedSettings) public ownerOnly {
+
+        Account storage account = submitedSettings[_proposedSettings];
+        require(whoSignedSettings[_proposedSettings][msg.sender] == false);
+        account.approvals += 1;
+        whoSignedSettings[_proposedSettings][msg.sender] == true;
+
+        if (account.approvals >= requiredSignatures) {
+            accountInfo[account.to];
+        
+            
+        }
+
+   }
+
+
+
+
+//     for(uint i = 0; i Account< owners.length; i++) {
+//         if (OwnersCheck[owners[i]] = true) {
+//             approvals ++;
+//         }
+
+//         if (approvals >= requiredSignatures) {
+//             accountInfo[msg.sender].withdrawdailyWithdrawlimit = dailyWithdrawlimit;
+//             delete pendingWithdrawaldailyWithdrawlimit[msg.sender];
+//             break;
+//         }
+//     }
+//    }
+
+    function withdraw(uint amount) public ownerOnly {
+        require(amount <= accountInfo[msg.sender].withdrawdailyWithdrawlimit, "Exceeded withdraw limit");
+        require(block.timestamp >= accountInfo[msg.sender].lastWithdrawalTimestamp + 1 days, "Daily limit haven't reset yet");
+        require(amount <= address(this).balance, "Insufficient balance");
+        payable(msg.sender).transfer(amount);
    }
 
         // View contract Spades balance 


### PR DESCRIPTION
In this branch I've built a structure to keep track of an account withdraw timestamp and limit. 
The `submitAccountLimit` function lets each owner submit proposals for withdraw limits in others accounts, the proposals will be executed if the required signatures are met.
Like in a transaction, I used a mapping to store all proposals indexes.
The `signSettings` function, allows owners to sign on a specific proposal. This will call an internal function that executes all the logic of signing a proposal.
Made a `withdraw` function to be called by an owner. This owner can only withdraw up to the withdraw limit.